### PR TITLE
refactor: ES module architecture + pure functions + tests (v2.0)

### DIFF
--- a/catalog.js
+++ b/catalog.js
@@ -13,7 +13,7 @@
  *   descriptionHint      – Platzhaltertext fürs Beschreibungsfeld
  *   fields               – Voreinstellungen für alle Formularfelder
  */
-const PROMPT_CATALOG = [
+export const PROMPT_CATALOG = [
 
   // ── Content ──────────────────────────────────────────────────────────────
   {
@@ -804,7 +804,7 @@ const PROMPT_CATALOG = [
  * Same IDs, icons, categories and field values as PROMPT_CATALOG.
  * Only name and descriptionHint are translated.
  */
-const PROMPT_CATALOG_EN = [
+export const PROMPT_CATALOG_EN = [
 
   // ── Content ──────────────────────────────────────────────────────────────
   { id: 'seo-blogartikel',      name: 'SEO Blog Post',        icon: 'fa-solid fa-magnifying-glass',   category: 'Content',      descriptionHint: 'Topic, main keyword, desired search intent …' },

--- a/examples.js
+++ b/examples.js
@@ -5,7 +5,7 @@
  * Add new prompts by appending an object to the array – no backend needed.
  * Fields: id, title, category, lang ('de'|'en'), text
  */
-const LIBRARY_EXAMPLES = [
+export const LIBRARY_EXAMPLES = [
 
   // ── Content ──────────────────────────────────────────────────────────────
 

--- a/index.html
+++ b/index.html
@@ -1272,9 +1272,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="catalog.js"></script>
-  <script src="examples.js"></script>
-  <script src="script.js"></script>
+  <script type="module" src="src/app.js"></script>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,15 @@
 import { PROMPT_CATALOG, PROMPT_CATALOG_EN } from './catalog.js';
 import { LIBRARY_EXAMPLES } from './examples.js';
+import {
+  LENGTH_MAP, LENGTH_MAP_EN,
+  ADDRESS_MAP, ADDRESS_MAP_EN,
+  FORMAT_MAP_EN, STYLE_MAP_EN,
+  AUDIENCE_MAP_EN, PERSPECTIVE_MAP_EN,
+  ARTICLE_MAP, ARTICLE_MAP_EN,
+} from './src/mappings.js';
+import { analyzePrompt } from './src/analyzer.js';
+import { buildFlowPrompt, buildFlowPromptEN, buildCtxPreviewText } from './src/prompt-builder.js';
+import { buildVariations } from './src/variations.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -83,109 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const val = (id) => (document.getElementById(id)?.value ?? '').trim();
 
-  // ── Mappings ──────────────────────────────────────────────────────────────
-  const LENGTH_MAP = {
-    'Sehr kurz (50–100 Wörter)':  'Sehr kurz',
-    'Kurz (100–300 Wörter)':      'Kurz',
-    'Mittel (300–600 Wörter)':    'Mittel',
-    'Lang (600–1.200 Wörter)':    'Lang',
-    'Sehr lang (1.200+ Wörter)':  'Sehr lang',
-  };
-
-  const LENGTH_MAP_EN = {
-    'Sehr kurz (50–100 Wörter)':  'very short (50–100 words)',
-    'Kurz (100–300 Wörter)':      'short (100–300 words)',
-    'Mittel (300–600 Wörter)':    'medium (300–600 words)',
-    'Lang (600–1.200 Wörter)':    'long (600–1,200 words)',
-    'Sehr lang (1.200+ Wörter)':  'very long (1,200+ words)',
-  };
-
-  const ADDRESS_MAP    = { formal: 'Sie-Form', informell: 'Du-Form', neutral: 'Neutral', kombiniert: 'Kombiniert' };
-  const ADDRESS_MAP_EN = { formal: 'formal (Sie)', informell: 'informal (du)', neutral: 'neutral', kombiniert: 'mixed' };
-
-  const FORMAT_MAP_EN = {
-    'Fließtext':               'flowing prose',
-    'Überschriften + Fließtext': 'headings with prose',
-    'Bullet Points':           'bullet points',
-    'Nummerierte Liste':       'numbered list',
-    'Schritt-für-Schritt':     'step-by-step',
-    'Tabellarisch':            'tabular layout',
-    'Zitat':                   'quote format',
-    'FAQ-Format (Frage & Antwort)': 'FAQ format (Q&A)',
-    'Checkliste / Aufgabenliste':   'checklist / task list',
-  };
-
-  const STYLE_MAP_EN = {
-    'Emotional': 'emotional', 'Empathisch': 'empathetic', 'Formell': 'formal',
-    'Humorvoll': 'humorous', 'Informell': 'informal', 'Inspirierend': 'inspiring',
-    'Journalistisch': 'journalistic', 'Minimalistisch': 'minimalist',
-    'Motivierend': 'motivational', 'Persönlich': 'personal', 'Poetisch': 'poetic',
-    'Provokativ': 'provocative', 'Sachlich': 'factual', 'Seriös': 'serious',
-    'Storytelling': 'storytelling', 'Technisch': 'technical',
-    'Umgangssprachlich': 'colloquial', 'Werblich': 'promotional',
-    'Wissenschaftlich': 'scientific',
-  };
-
-  const AUDIENCE_MAP_EN = {
-    'Jugendliche (16–25 Jahre)':        'teenagers and young adults (16–25)',
-    'Junge Erwachsene (25–35 Jahre)':   'young adults (25–35)',
-    'Berufstätige (30–50 Jahre)':       'working professionals (30–50)',
-    'Eltern & Familien':                'parents and families',
-    'Senioren (50+ Jahre)':             'seniors (50+)',
-    'Gründer & Startups':               'founders and startups',
-    'KMU-Inhaber & Selbstständige':     'SME owners and freelancers',
-    'Manager & Führungskräfte':         'managers and executives',
-    'B2B-Entscheider':                  'B2B decision-makers',
-    'IT-Professionals':                 'IT professionals',
-    'Technik & Digitales':              'tech enthusiasts',
-    'Fitness & Gesundheit':             'fitness and health community',
-    'Mode & Lifestyle':                 'fashion and lifestyle audience',
-    'Finanzen & Investment':            'finance and investment community',
-    'Bildung & Weiterbildung':          'education and learning community',
-    'Schüler & Auszubildende (15–22 Jahre)': 'students and trainees (15–22)',
-    'Kreative & Designer':              'creatives and designers',
-    'Lehrkräfte & Pädagogen':           'teachers and educators',
-    'Sport & Outdoor':                  'sports and outdoor enthusiasts',
-    'Nachhaltigkeit & Umwelt':          'sustainability and environmental community',
-  };
-
-  const PERSPECTIVE_MAP_EN = {
-    'Du-Perspektive': 'second person (you)',
-    'Er-/Sie-Perspektive': 'third person',
-    'Ich-Perspektive': 'first person (I)',
-    'Neutral/Objektiv': 'neutral/objective',
-    'Wir-Perspektive': 'first person plural (we)',
-  };
-
-  const ARTICLE_MAP = {
-    'Artikel': 'einen ', 'Blog-Post': 'einen ', 'How-to-Anleitung': 'eine ', 'Listicle (Top-X-Artikel)': 'einen ',
-    'Interview': 'ein ', 'Whitepaper': 'ein ', 'Case-Study': 'eine ',
-    'Pressemitteilung': 'eine ', 'E-Book': 'ein ', 'Buchrezension': 'eine ', 'Zusammenfassung': 'eine ',
-    'Facebook-Beitrag': 'einen ', 'Instagram-Beitrag': 'einen ',
-    'Story-Skript (Instagram / Facebook)': 'ein ', 'Carousel-Post': 'einen ',
-    'LinkedIn-Beitrag': 'einen ', 'Twitter-Beitrag': 'einen ',
-    'TikTok-Skript': 'ein ', 'Reels-Skript': 'ein ',
-    'Threads-Beitrag': 'einen ', 'Xing-Beitrag': 'einen ',
-    'Produktbeschreibung': 'eine ', 'Verkaufstext / Sales Page': 'einen ', 'Produktvergleich': 'einen ',
-    'FAQ-Seite': 'eine ', 'Anzeige': 'eine ', 'SEO-Text': 'einen ',
-    'Newsletter': 'einen ', 'Landing Page': 'eine ',
-    'E-Mail': 'eine ', 'Kaltakquise-E-Mail': 'eine ', 'Follow-up-E-Mail': 'eine ',
-    'Onboarding-E-Mail': 'eine ', 'Kundenservice-Antwort': 'eine ',
-    'Präsentation': 'eine ', 'Executive Summary': 'ein ', 'Bericht / Report': 'einen ',
-    'Angebot / Proposal': 'ein ', 'Meeting-Protokoll': 'ein ',
-    'Stellenanzeige': 'eine ', 'Bewerbungsschreiben': 'ein ',
-    'YouTube-Video': 'ein ', 'YouTube-Short-Skript': 'ein ',
-    'Podcast-Episode': 'eine ', 'Infografik': 'eine ',
-    'Webinar': 'ein ', 'Live-Stream': 'einen ',
-    'Slogan / Claim': 'einen ', 'Kurzgeschichte': 'eine ',
-    'Gedicht / Lyrik': 'ein ', 'Drehbuch / Skript': 'ein ',
-    'Online-Quiz': 'ein ', 'Chatbot': 'einen ', 'Online-Kurs': 'einen ',
-    'Erfahrungsbericht': 'einen ', 'Checkliste': 'eine ', 'Glossar / Lexikon': 'ein ',
-    'Produkttest / Review': 'einen ', 'Meta-Description (SEO)': 'eine ',
-    'Einladungsschreiben': 'ein ', 'Dankes-E-Mail': 'eine ',
-    'Unternehmensvorstellung': 'eine ', 'Vision & Mission Statement': 'ein ',
-    'Produktname / Naming': 'ein ',
-  };
+  // Mappings → src/mappings.js
 
   // ── Option label translations (value stays German key, display text translates) ──
   const OPTION_LABELS = {
@@ -412,40 +320,7 @@ document.addEventListener('DOMContentLoaded', () => {
     },
   };
 
-  const ARTICLE_MAP_EN = {
-    'Artikel': 'an article', 'Blog-Post': 'a blog post',
-    'How-to-Anleitung': 'a how-to guide', 'Listicle (Top-X-Artikel)': 'a listicle',
-    'Interview': 'an interview', 'Whitepaper': 'a whitepaper',
-    'Case-Study': 'a case study', 'Pressemitteilung': 'a press release', 'E-Book': 'an e-book',
-    'Buchrezension': 'a book review', 'Zusammenfassung': 'a summary',
-    'Facebook-Beitrag': 'a Facebook post', 'Instagram-Beitrag': 'an Instagram caption',
-    'Story-Skript (Instagram / Facebook)': 'a story script', 'Carousel-Post': 'a carousel post',
-    'LinkedIn-Beitrag': 'a LinkedIn post', 'Twitter-Beitrag': 'a tweet',
-    'TikTok-Skript': 'a TikTok script', 'Reels-Skript': 'a Reels script',
-    'Threads-Beitrag': 'a Threads post', 'Xing-Beitrag': 'a Xing post',
-    'Produktbeschreibung': 'a product description', 'Verkaufstext / Sales Page': 'a sales page',
-    'Produktvergleich': 'a product comparison', 'FAQ-Seite': 'an FAQ page',
-    'Anzeige': 'an advertisement', 'SEO-Text': 'an SEO article',
-    'Newsletter': 'a newsletter', 'Landing Page': 'a landing page',
-    'E-Mail': 'an email', 'Kaltakquise-E-Mail': 'a cold outreach email',
-    'Follow-up-E-Mail': 'a follow-up email', 'Onboarding-E-Mail': 'an onboarding email',
-    'Kundenservice-Antwort': 'a customer service response',
-    'Präsentation': 'a presentation', 'Executive Summary': 'an executive summary',
-    'Bericht / Report': 'a report', 'Angebot / Proposal': 'a business proposal',
-    'Meeting-Protokoll': 'a meeting minutes document',
-    'Stellenanzeige': 'a job posting', 'Bewerbungsschreiben': 'a cover letter',
-    'YouTube-Video': 'a YouTube video description', 'YouTube-Short-Skript': 'a YouTube Shorts script',
-    'Podcast-Episode': 'a podcast episode outline',
-    'Infografik': 'an infographic', 'Webinar': 'a webinar', 'Live-Stream': 'a live stream script',
-    'Slogan / Claim': 'a slogan', 'Kurzgeschichte': 'a short story',
-    'Gedicht / Lyrik': 'a poem', 'Drehbuch / Skript': 'a script',
-    'Online-Quiz': 'an online quiz', 'Chatbot': 'a chatbot script', 'Online-Kurs': 'an online course outline',
-    'Erfahrungsbericht': 'a testimonial / experience report', 'Checkliste': 'a checklist',
-    'Glossar / Lexikon': 'a glossary', 'Produkttest / Review': 'a product review',
-    'Meta-Description (SEO)': 'a meta description', 'Einladungsschreiben': 'an invitation letter',
-    'Dankes-E-Mail': 'a thank-you email', 'Unternehmensvorstellung': 'a company introduction',
-    'Vision & Mission Statement': 'a vision & mission statement', 'Produktname / Naming': 'a product name concept',
-  };
+  // ARTICLE_MAP_EN → src/mappings.js
 
   // ── Preview groups ────────────────────────────────────────────────────────
   const PREVIEW_GROUPS = [
@@ -481,92 +356,15 @@ document.addEventListener('DOMContentLoaded', () => {
     { key: 'beispiel', icon: 'fa-lightbulb',     getValue: () => val('beispiel') },
   ];
 
-  // ── Build prompts ─────────────────────────────────────────────────────────
-  const buildFlowPrompt = () => {
-    const role = val('role-definition'),
-          type = val('content-type'), description = val('description'),
-          audience = val('target-audience'), length = val('content-length'),
-          formatting = val('formatting'), seo = val('seo-keyword-option'),
-          titleSub = val('title-subtitle-option'), perspective = val('perspective'),
-          addressForm = val('address-form'), style = val('language-style'),
-          emojis = val('emoji-option'), beispiel = val('beispiel');
-
-    if (!role && !type && !description) return '';
-    const s = [];
-
-    const _ctxDE = buildCtxPreviewText(loadProjectCtx());
-    if (_ctxDE) s.push(_ctxDE);
-    if (role) s.push(role.endsWith('.') || role.endsWith('!') || role.endsWith('?') ? role : role + '.');
-    if (type) s.push(`Erstelle ${(ARTICLE_MAP[type] ?? 'einen ')}${type}.`);
-    if (description && audience) s.push(`Das Thema lautet: ${description}. Die Zielgruppe sind ${audience}.`);
-    else if (description) s.push(`Das Thema lautet: ${description}.`);
-    else if (audience) s.push(`Die Zielgruppe sind ${audience}.`);
-
-    const fp = [];
-    if (length) fp.push(`Textlänge ${LENGTH_MAP[length] || length}`);
-    if (formatting) fp.push(`Formatierung als ${formatting}`);
-    if (seo === 'Ja') fp.push('inklusive SEO-Keywords');
-    if (titleSub === 'ja') fp.push('mit Titel und Untertitel');
-    if (emojis === 'keine') fp.push('ohne Emojis');
-    else if (emojis === 'wenige') fp.push('mit wenigen Emojis');
-    else if (emojis === 'viele') fp.push('mit vielen Emojis');
-    if (fp.length) s.push(`Verwende ${fp.join(', ')}.`);
-
-    const pp = [];
-    if (perspective) pp.push(perspective);
-    if (addressForm) pp.push(ADDRESS_MAP[addressForm] || addressForm);
-    if (pp.length) s.push(`Schreibe aus der ${pp.join(', in der ')}.`);
-    if (style) s.push(`Der Sprachstil soll ${style.toLowerCase()} sein.`);
-    if (beispiel) s.push(`Orientiere dich stilistisch an folgendem Beispiel: ${beispiel}`);
-
-    return s.join(' ');
-  };
-
-  const buildFlowPromptEN = () => {
-    const role = val('role-definition'),
-          type = val('content-type'), description = val('description'),
-          audience = val('target-audience'), length = val('content-length'),
-          formatting = val('formatting'), seo = val('seo-keyword-option'),
-          titleSub = val('title-subtitle-option'), perspective = val('perspective'),
-          addressForm = val('address-form'), style = val('language-style'),
-          emojis = val('emoji-option'), beispiel = val('beispiel');
-
-    if (!role && !type && !description) return '';
-    const s = [];
-
-    const _ctxEN = buildCtxPreviewText(loadProjectCtx());
-    if (_ctxEN) s.push(_ctxEN);
-    if (role) s.push(role.endsWith('.') || role.endsWith('!') || role.endsWith('?') ? role : role + '.');
-    if (type) s.push(`Create ${ARTICLE_MAP_EN[type] ?? 'a ' + type}.`);
-    if (description && audience)
-      s.push(`The topic is: ${description}. The target audience is ${AUDIENCE_MAP_EN[audience] || audience}.`);
-    else if (description) s.push(`The topic is: ${description}.`);
-    else if (audience) s.push(`The target audience is ${AUDIENCE_MAP_EN[audience] || audience}.`);
-
-    const fp = [];
-    if (length) fp.push(`text length: ${LENGTH_MAP_EN[length] || length}`);
-    if (formatting) fp.push(`format: ${FORMAT_MAP_EN[formatting] || formatting}`);
-    if (seo === 'Ja') fp.push('include SEO keywords');
-    if (titleSub === 'ja') fp.push('include title and subtitle');
-    if (emojis === 'keine') fp.push('no emojis');
-    else if (emojis === 'wenige') fp.push('few emojis');
-    else if (emojis === 'viele') fp.push('many emojis');
-    if (fp.length) s.push(`Use the following: ${fp.join(', ')}.`);
-
-    const pp = [];
-    if (perspective) pp.push(PERSPECTIVE_MAP_EN[perspective] || perspective);
-    if (addressForm) pp.push(ADDRESS_MAP_EN[addressForm] || addressForm);
-    if (pp.length) s.push(`Write from a ${pp.join(', ')} perspective.`);
-    if (style) s.push(`The tone should be ${STYLE_MAP_EN[style] || style.toLowerCase()}.`);
-    if (beispiel) s.push(`Stylistically, follow this example: ${beispiel}`);
-
-    return s.join(' ');
-  };
+  // buildFlowPrompt / buildFlowPromptEN → src/prompt-builder.js
 
   // ── Language state ────────────────────────────────────────────────────────
   let activeLang = 'de';
 
-  const getCurrentPrompt = () => activeLang === 'en' ? buildFlowPromptEN() : buildFlowPrompt();
+  const _fields = () => Object.fromEntries(FIELD_IDS.map(id => [id, val(id)]).filter(([, v]) => v));
+  const getCurrentPrompt = () => activeLang === 'en'
+    ? buildFlowPromptEN(_fields(), loadProjectCtx())
+    : buildFlowPrompt(_fields(), loadProjectCtx());
 
   if (langToggle) {
     langToggle.addEventListener('click', e => {
@@ -584,138 +382,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .replace(/&/g, '&amp;').replace(/</g, '&lt;')
     .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
-  // ── Prompt Reverse-Engineer (Feature: Analysieren) ───────────────────────
-  const analyzePrompt = (text) => {
-    const result = {};
-
-    // Role / Persona
-    const rolePatterns = [
-      /(?:du bist|sie sind|agiere als|handele als)\s+([^.!?\n]{5,120})/i,
-      /(?:act as|you are|you're)\s+([^.!?\n]{5,120})/i,
-    ];
-    for (const p of rolePatterns) {
-      const m = text.match(p);
-      if (m) { result['role-definition'] = m[0].trim().replace(/[,.]$/, ''); break; }
-    }
-
-    // Content type
-    const typePatterns = [
-      { p: /pressemitteilung|press.?release/i,             v: 'Pressemitteilung' },
-      { p: /whitepaper/i,                                  v: 'Whitepaper' },
-      { p: /case.?stud/i,                                  v: 'Case-Study' },
-      { p: /newsletter/i,                                  v: 'Newsletter' },
-      { p: /landing.?page/i,                               v: 'Landing Page' },
-      { p: /linkedin/i,                                    v: 'LinkedIn-Beitrag' },
-      { p: /instagram/i,                                   v: 'Instagram-Beitrag' },
-      { p: /facebook/i,                                    v: 'Facebook-Beitrag' },
-      { p: /tweet|twitter/i,                               v: 'Twitter-Beitrag' },
-      { p: /tiktok/i,                                      v: 'TikTok-Skript' },
-      { p: /youtube/i,                                     v: 'YouTube-Video' },
-      { p: /podcast/i,                                     v: 'Podcast-Episode' },
-      { p: /executive.?summary/i,                          v: 'Executive Summary' },
-      { p: /bericht|report(?!\w)/i,                        v: 'Bericht / Report' },
-      { p: /stellenanzeige|job.?posting/i,                 v: 'Stellenanzeige' },
-      { p: /produktbeschreibung|product.?description/i,    v: 'Produktbeschreibung' },
-      { p: /seo.?text|seo.?artikel|seo.?article/i,        v: 'SEO-Text' },
-      { p: /how.?to|schritt.?für.?schritt|step.?by.?step/i, v: 'How-to-Anleitung' },
-      { p: /kaltakquise|cold.?outreach|cold.?email/i,     v: 'Kaltakquise-E-Mail' },
-      { p: /follow.?up/i,                                  v: 'Follow-up-E-Mail' },
-      { p: /e.?mail|email/i,                               v: 'E-Mail' },
-      { p: /präsentation|presentation/i,                   v: 'Präsentation' },
-      { p: /blog.?post|blogartikel/i,                      v: 'Blog-Post' },
-      { p: /artikel|article/i,                             v: 'Artikel' },
-    ];
-    for (const { p, v } of typePatterns) {
-      if (p.test(text)) { result['content-type'] = v; break; }
-    }
-
-    // Length
-    const wordMatch = text.match(/(\d+)\s*(?:wörter|wörtern|words)/i);
-    if (wordMatch) {
-      const n = parseInt(wordMatch[1]);
-      if (n <= 100)       result['content-length'] = 'Sehr kurz (50–100 Wörter)';
-      else if (n <= 300)  result['content-length'] = 'Kurz (100–300 Wörter)';
-      else if (n <= 600)  result['content-length'] = 'Mittel (300–600 Wörter)';
-      else if (n <= 1200) result['content-length'] = 'Lang (600–1.200 Wörter)';
-      else                result['content-length'] = 'Sehr lang (1.200+ Wörter)';
-    } else if (/\bkurz\b|brief|concise/i.test(text)) {
-      result['content-length'] = 'Kurz (100–300 Wörter)';
-    } else if (/ausführlich|detailliert|detailed|comprehensive|lang\b/i.test(text)) {
-      result['content-length'] = 'Lang (600–1.200 Wörter)';
-    }
-
-    // Style
-    const stylePatterns = [
-      { p: /wissenschaftlich|academic|scholarly/i,   v: 'Wissenschaftlich' },
-      { p: /journalistisch|journalistic/i,            v: 'Journalistisch' },
-      { p: /werblich|promotional/i,                   v: 'Werblich' },
-      { p: /technisch|technical/i,                    v: 'Technisch' },
-      { p: /humorvoll|humor|witzig|funny/i,           v: 'Humorvoll' },
-      { p: /inspir/i,                                 v: 'Inspirierend' },
-      { p: /emotiona/i,                               v: 'Emotional' },
-      { p: /motivier|motivat/i,                       v: 'Motivierend' },
-      { p: /sachlich|factual|neutral/i,               v: 'Sachlich' },
-      { p: /persönlich|personal/i,                    v: 'Persönlich' },
-      { p: /storytelling/i,                           v: 'Storytelling' },
-      { p: /formell|formal|professionell|professional/i, v: 'Formell' },
-      { p: /informell|locker|casual|informal/i,       v: 'Informell' },
-    ];
-    for (const { p, v } of stylePatterns) {
-      if (p.test(text)) { result['language-style'] = v; break; }
-    }
-
-    // Audience
-    const audiencePatterns = [
-      { p: /b2b.{0,20}entscheider|b2b.{0,20}decision/i, v: 'B2B-Entscheider' },
-      { p: /manager|führungskraft|executive|c-?level/i,  v: 'Manager & Führungskräfte' },
-      { p: /startup|gründer|founder/i,                   v: 'Gründer & Startups' },
-      { p: /it.?profes|entwickler|developer|programmer/i,v: 'IT-Professionals' },
-      { p: /senior|50\+|ältere/i,                        v: 'Senioren (50+ Jahre)' },
-      { p: /jugend|teenager|16.{0,3}25/i,                v: 'Jugendliche (16–25 Jahre)' },
-      { p: /schüler|student|auszubildend/i,              v: 'Schüler & Auszubildende (15–22 Jahre)' },
-      { p: /eltern|famili|parent|family/i,               v: 'Eltern & Familien' },
-      { p: /kreativ|designer|creative/i,                 v: 'Kreative & Designer' },
-      { p: /b2b|unternehmen|geschäftskund/i,             v: 'Manager & Führungskräfte' },
-    ];
-    for (const { p, v } of audiencePatterns) {
-      if (p.test(text)) { result['target-audience'] = v; break; }
-    }
-
-    // Formatting
-    if (/bullet.?point|aufzählung|stichpunkt/i.test(text))              result['formatting'] = 'Bullet Points';
-    else if (/tabelle|tabellarisch|table/i.test(text))                  result['formatting'] = 'Tabellarisch';
-    else if (/faq/i.test(text))                                         result['formatting'] = 'FAQ-Format (Frage & Antwort)';
-    else if (/checkliste|checklist/i.test(text))                        result['formatting'] = 'Checkliste / Aufgabenliste';
-    else if (/überschrift|heading|mit abschnitt/i.test(text))           result['formatting'] = 'Überschriften + Fließtext';
-
-    // SEO
-    if (/seo.?keyword|keyword|schlüsselwort/i.test(text))              result['seo-keyword-option'] = 'Ja';
-
-    // Emojis
-    if (/ohne emoji|no emoji/i.test(text))                             result['emoji-option'] = 'keine';
-    else if (/mit emoji|emojis|use emoji/i.test(text))                 result['emoji-option'] = 'wenige';
-
-    // Topic / Description — find the core sentence
-    const topicPatterns = [
-      /(?:zum thema|über das thema|thema\s*[:\-])\s*([^.!?\n]{10,200})/i,
-      /(?:topic\s*[:\-]|about\s*[:\-]?|über\s*[:\-]?)\s*([^.!?\n]{10,200})/i,
-    ];
-    for (const p of topicPatterns) {
-      const m = text.match(p);
-      if (m) { result['description'] = m[1].trim(); break; }
-    }
-    if (!result['description']) {
-      // Fall back: first non-command sentence of reasonable length
-      const sentences = text.split(/[.!?]/).map(s => s.trim())
-        .filter(s => s.length > 25 && !/^(?:du bist|you are|act as|erstelle|create|write|schreibe|erzeuge|generate)/i.test(s));
-      if (sentences[0]) {
-        const s = sentences[0];
-        result['description'] = s.length > 160 ? s.substring(0, 160) + '…' : s;
-      }
-    }
-
-    return result;
-  };
+  // analyzePrompt → src/analyzer.js
 
   // ── Projekt-Kontext ───────────────────────────────────────────────────────
   const loadProjectCtx = () => {
@@ -733,14 +400,7 @@ document.addEventListener('DOMContentLoaded', () => {
     dot.classList.toggle('d-none', !hasContent);
   };
 
-  const buildCtxPreviewText = (ctx) => {
-    if (!ctx.active) return '';
-    const parts = [];
-    if (ctx.company)  parts.push(`Firma/Projekt: ${ctx.company}`);
-    if (ctx.industry) parts.push(`Branche: ${ctx.industry}`);
-    if (ctx.extra)    parts.push(ctx.extra);
-    return parts.length ? `[Projekt-Kontext: ${parts.join(' · ')}]` : '';
-  };
+  // buildCtxPreviewText → src/prompt-builder.js
 
   const renderCtxPreview = () => {
     const box  = document.getElementById('ctx-preview-box');
@@ -1778,8 +1438,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const compareModal = new bootstrap.Modal(document.getElementById('compareModal'));
 
   document.getElementById('btn-compare')?.addEventListener('click', () => {
-    document.getElementById('compare-text-de').textContent = buildFlowPrompt()   || '–';
-    document.getElementById('compare-text-en').textContent = buildFlowPromptEN() || '–';
+    const f = _fields(), ctx = loadProjectCtx();
+    document.getElementById('compare-text-de').textContent = buildFlowPrompt(f, ctx)   || '–';
+    document.getElementById('compare-text-en').textContent = buildFlowPromptEN(f, ctx) || '–';
     compareModal.show();
   });
 
@@ -1787,7 +1448,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const btn = e.target.closest('.compare-copy-btn');
     if (!btn) return;
     const lang = btn.dataset.lang;
-    const text = lang === 'en' ? buildFlowPromptEN() : buildFlowPrompt();
+    const f = _fields(), ctx = loadProjectCtx();
+    const text = lang === 'en' ? buildFlowPromptEN(f, ctx) : buildFlowPrompt(f, ctx);
     try { await navigator.clipboard.writeText(text); } catch {
       const ta = Object.assign(document.createElement('textarea'),
         { value: text, style: 'position:fixed;opacity:0;' });
@@ -1923,105 +1585,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (e.target.classList.contains('onboarding-backdrop')) closeOnboarding();
   });
 
-  // ── Prompt Variationen ────────────────────────────────────────────────────
-  const buildVariations = () => {
-    const type = val('content-type'), description = val('description'),
-          audience = val('target-audience'), length = val('content-length'),
-          formatting = val('formatting'), seo = val('seo-keyword-option'),
-          titleSub = val('title-subtitle-option'), perspective = val('perspective'),
-          addressForm = val('address-form'), style = val('language-style'),
-          emojis = val('emoji-option'), beispiel = val('beispiel');
-
-    if (!type && !description) return [];
-
-    if (uiLang === 'en') {
-      const art = ARTICLE_MAP_EN[type] ?? 'a ' + (type || '');
-      const fp = [];
-      if (length)   fp.push(LENGTH_MAP_EN[length] || length);
-      if (formatting) fp.push(FORMAT_MAP_EN[formatting] || formatting);
-      if (seo === 'Ja') fp.push('SEO keywords');
-      if (titleSub === 'ja') fp.push('title');
-      if (emojis === 'keine') fp.push('no emojis');
-      else if (emojis === 'wenige') fp.push('few emojis');
-      else if (emojis === 'viele') fp.push('many emojis');
-      const fmt = fp.join(', ');
-      const aud = AUDIENCE_MAP_EN[audience] || audience;
-      const sty = STYLE_MAP_EN[style] || style;
-
-      const v1 = [];
-      if (type) v1.push(`Write ${art}.`);
-      if (description) v1.push(`Topic: ${description}.`);
-      if (audience)    v1.push(`Audience: ${aud}.`);
-      if (fmt)         v1.push(`Format: ${fmt}.`);
-      if (style)       v1.push(`Style: ${sty}.`);
-      if (beispiel)    v1.push(`Reference: ${beispiel}`);
-
-      const v2 = [];
-      if (description) v2.push(`About "${description}": `);
-      if (type)        v2.push(`Write ${art}${audience ? ` for ${aud}` : ''}.`);
-      const det = [];
-      if (fmt)   det.push(fmt);
-      if (style) det.push(`${sty} tone`);
-      if (perspective) det.push(PERSPECTIVE_MAP_EN[perspective] || perspective);
-      if (det.length) v2.push(`Consider: ${det.join(', ')}.`);
-      if (beispiel) v2.push(`Base your style on: ${beispiel}`);
-
-      const v3 = [];
-      v3.push(style ? `You are a ${sty} copywriter.` : 'You are an experienced copywriter.');
-      if (type && description) v3.push(`Create ${art} about: ${description}.`);
-      else if (type)            v3.push(`Create ${art}.`);
-      if (audience) v3.push(`Target audience: ${aud}.`);
-      if (fmt)      v3.push(`Format: ${fmt}.`);
-      if (addressForm) v3.push(`Use ${ADDRESS_MAP_EN[addressForm] || addressForm} address form.`);
-      if (beispiel) v3.push(`Style reference: ${beispiel}`);
-
-      return [v1.join(' '), v2.join(''), v3.join(' ')].filter(v => v.trim().length > 5);
-    }
-
-    const art = ARTICLE_MAP[type] ?? 'einen ';
-    const fp = [];
-    if (length)   fp.push(LENGTH_MAP[length] || length);
-    if (formatting) fp.push(formatting);
-    if (seo === 'Ja') fp.push('SEO-Keywords');
-    if (titleSub === 'ja') fp.push('Titel');
-    if (emojis === 'keine') fp.push('keine Emojis');
-    else if (emojis === 'wenige') fp.push('wenige Emojis');
-    else if (emojis === 'viele') fp.push('viele Emojis');
-    const fmt = fp.join(', ');
-
-    const v1 = [];
-    if (type) v1.push(`Verfasse ${art}${type}.`);
-    if (description) v1.push(`Thema: ${description}.`);
-    if (audience)    v1.push(`Zielgruppe: ${audience}.`);
-    if (fmt)         v1.push(`Format: ${fmt}.`);
-    if (style)       v1.push(`Stil: ${style}.`);
-    if (beispiel)    v1.push(`Referenz: ${beispiel}`);
-
-    const v2 = [];
-    if (description) v2.push(`Zum Thema „${description}": `);
-    if (type)        v2.push(`Schreibe ${art}${type}${audience ? ` für ${audience}` : ''}.`);
-    const det = [];
-    if (fmt)   det.push(fmt);
-    if (style) det.push(`${style.toLowerCase()} Stil`);
-    if (perspective) det.push(perspective);
-    if (det.length) v2.push(`Berücksichtige: ${det.join(', ')}.`);
-    if (beispiel) v2.push(`Orientiere dich an: ${beispiel}`);
-
-    const v3 = [];
-    v3.push(style ? `Du bist ein ${style.toLowerCase()} schreibender Texter.` : 'Du bist ein erfahrener Texter.');
-    if (type && description) v3.push(`Erstelle ${art}${type} über: ${description}.`);
-    else if (type)            v3.push(`Erstelle ${art}${type}.`);
-    if (audience) v3.push(`Zielgruppe: ${audience}.`);
-    if (fmt)      v3.push(`Format: ${fmt}.`);
-    if (addressForm) v3.push(`Schreibe in der ${ADDRESS_MAP[addressForm] || addressForm}.`);
-    if (beispiel) v3.push(`Stilreferenz: ${beispiel}`);
-
-    return [v1.join(' '), v2.join(''), v3.join(' ')].filter(v => v.trim().length > 5);
-  };
+  // buildVariations → src/variations.js
 
   const showVariations = () => {
     const t = UI_STRINGS[uiLang] || UI_STRINGS.de;
-    const vars = buildVariations();
+    const vars = buildVariations(_fields(), uiLang);
     const list = document.getElementById('variations-list');
     if (!list) return;
     if (!vars.length) {

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
-'use strict';
+import { PROMPT_CATALOG, PROMPT_CATALOG_EN } from './catalog.js';
+import { LIBRARY_EXAMPLES } from './examples.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -73,7 +74,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const LS_FAVORITES_KEY  = 'chati_favorites';
   const LS_THEME_KEY      = 'chati_theme';
   const LS_PROJECT_CTX    = 'chati_project_ctx';
+  const LS_RECENT_KEY     = 'chati_recent';
+  const LS_ONBOARDED_KEY  = 'chati_onboarded';
+  const LS_VAULT_KEY      = 'chati_vault';
+  const LS_UI_LANG_KEY    = 'chati_ui_lang';
   const HISTORY_MAX     = 8;
+  const VAULT_MAX       = 10;
 
   const val = (id) => (document.getElementById(id)?.value ?? '').trim();
 
@@ -1113,7 +1119,6 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   // Feature 11: Recently used templates
-  const LS_RECENT_KEY = 'chati_recent';
   const loadRecent = () => { try { return JSON.parse(localStorage.getItem(LS_RECENT_KEY)) || []; } catch { return []; } };
   const saveRecent = (id, name, category) => {
     const items = loadRecent().filter(r => r.id !== id);
@@ -1834,8 +1839,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // ── Feature 6: Onboarding Tour ────────────────────────────────────────────
-  const LS_ONBOARDED_KEY = 'chati_onboarded';
-
   const ONBOARDING_STEPS = [
     {
       icon: 'fa-wand-magic-sparkles',
@@ -2429,7 +2432,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (fmLabel) fmLabel.textContent = focusMode ? t['btn.focusExit'] : t['btn.focus'];
 
     if (uiLangLabel) uiLangLabel.textContent = lang === 'de' ? 'EN' : 'DE';
-    try { localStorage.setItem('chati_ui_lang', lang); } catch {}
+    try { localStorage.setItem(LS_UI_LANG_KEY, lang); } catch {}
     renderCatalog(activeFilter);
     renderLibrary();
     renderPresets();
@@ -2912,9 +2915,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btn-inspire')?.addEventListener('click', inspireRandom);
 
   // ── Persona-Vault (Feature: Persona-Vault v1.9) ───────────────────────────
-  const LS_VAULT_KEY = 'chati_vault';
-  const VAULT_MAX    = 10;
-
   const loadVault = () => {
     try { return JSON.parse(localStorage.getItem(LS_VAULT_KEY)) || []; } catch { return []; }
   };

--- a/src/__tests__/analyzer.test.js
+++ b/src/__tests__/analyzer.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { analyzePrompt } from '../analyzer.js';
+import { buildFlowPrompt } from '../prompt-builder.js';
+
+describe('analyzePrompt — role detection', () => {
+  it('extracts German role pattern', () => {
+    const result = analyzePrompt('Du bist ein erfahrener Marketing-Experte mit 10 Jahren Erfahrung.');
+    expect(result['role-definition']).toBeTruthy();
+    expect(result['role-definition']).toContain('Marketing-Experte');
+  });
+
+  it('extracts English role pattern', () => {
+    const result = analyzePrompt('You are an experienced copywriter. Write a blog post.');
+    expect(result['role-definition']).toContain('experienced copywriter');
+  });
+
+  it('returns empty object for plain text without patterns', () => {
+    const result = analyzePrompt('The sky is blue.');
+    expect(result['role-definition']).toBeUndefined();
+  });
+});
+
+describe('analyzePrompt — content type detection', () => {
+  it('detects Blog-Post', () => {
+    const r = analyzePrompt('Schreibe einen Blogartikel über KI.');
+    expect(r['content-type']).toBe('Blog-Post');
+  });
+
+  it('detects Pressemitteilung', () => {
+    const r = analyzePrompt('Erstelle eine Pressemitteilung für unser neues Produkt.');
+    expect(r['content-type']).toBe('Pressemitteilung');
+  });
+
+  it('detects Newsletter', () => {
+    const r = analyzePrompt('Schreibe einen Newsletter für unsere Kunden.');
+    expect(r['content-type']).toBe('Newsletter');
+  });
+
+  it('detects LinkedIn post', () => {
+    const r = analyzePrompt('Erstelle einen LinkedIn-Post über unser Event.');
+    expect(r['content-type']).toBe('LinkedIn-Beitrag');
+  });
+
+  it('detects E-Mail', () => {
+    const r = analyzePrompt('Schreibe eine E-Mail an unsere Partner.');
+    expect(r['content-type']).toBe('E-Mail');
+  });
+});
+
+describe('analyzePrompt — length detection', () => {
+  it('maps 200 words to Kurz', () => {
+    const r = analyzePrompt('Schreibe einen Text mit 200 Wörtern.');
+    expect(r['content-length']).toBe('Kurz (100–300 Wörter)');
+  });
+
+  it('maps 800 words to Lang', () => {
+    const r = analyzePrompt('Write a text with 800 words about technology.');
+    expect(r['content-length']).toBe('Lang (600–1.200 Wörter)');
+  });
+
+  it('maps "kurz" keyword to Kurz', () => {
+    // The regex uses \bkurz\b — "kurz" must appear as a full word, not inflected
+    const r = analyzePrompt('Halte es kurz und prägnant.');
+    expect(r['content-length']).toBe('Kurz (100–300 Wörter)');
+  });
+});
+
+describe('analyzePrompt — style detection', () => {
+  it('detects journalistisch', () => {
+    const r = analyzePrompt('Schreibe in einem journalistischen Stil.');
+    expect(r['language-style']).toBe('Journalistisch');
+  });
+
+  it('detects formell/professional', () => {
+    const r = analyzePrompt('The tone should be professional and formal.');
+    expect(r['language-style']).toBe('Formell');
+  });
+
+  it('detects humorvoll', () => {
+    const r = analyzePrompt('Schreibe humorvoll und witzig.');
+    expect(r['language-style']).toBe('Humorvoll');
+  });
+});
+
+describe('analyzePrompt — formatting', () => {
+  it('detects Bullet Points', () => {
+    const r = analyzePrompt('Erstelle eine Aufzählung mit Bullet Points.');
+    expect(r['formatting']).toBe('Bullet Points');
+  });
+
+  it('detects FAQ format', () => {
+    const r = analyzePrompt('Schreibe im FAQ-Format mit Fragen und Antworten.');
+    expect(r['formatting']).toBe('FAQ-Format (Frage & Antwort)');
+  });
+});
+
+describe('analyzePrompt — SEO & emojis', () => {
+  it('detects SEO keywords request', () => {
+    const r = analyzePrompt('Inklusive SEO-Keywords für bessere Sichtbarkeit.');
+    expect(r['seo-keyword-option']).toBe('Ja');
+  });
+
+  it('detects no-emoji request', () => {
+    const r = analyzePrompt('Schreibe ohne Emojis und sachlich.');
+    expect(r['emoji-option']).toBe('keine');
+  });
+});
+
+describe('analyzePrompt — round-trip consistency', () => {
+  it('key fields survive a build → analyze round-trip', () => {
+    const original = {
+      'role-definition': 'Du bist ein erfahrener Marketing-Experte',
+      'content-type': 'Blog-Post',
+      'description': 'KI-Tools im Alltag',
+      'content-length': 'Kurz (100–300 Wörter)',
+    };
+    const prompt = buildFlowPrompt(original);
+    const analyzed = analyzePrompt(prompt);
+
+    expect(analyzed['role-definition']).toBeTruthy();
+    expect(analyzed['content-type']).toBe('Blog-Post');
+    expect(analyzed['content-length']).toBe('Kurz (100–300 Wörter)');
+  });
+});

--- a/src/__tests__/prompt-builder.test.js
+++ b/src/__tests__/prompt-builder.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFlowPrompt,
+  buildFlowPromptEN,
+  getCurrentPrompt,
+  buildCtxPreviewText,
+} from '../prompt-builder.js';
+
+describe('buildFlowPrompt (DE)', () => {
+  it('returns empty string when no role, type, or description', () => {
+    expect(buildFlowPrompt({})).toBe('');
+    expect(buildFlowPrompt({ 'language-style': 'Sachlich' })).toBe('');
+  });
+
+  it('includes role with trailing period when missing punctuation', () => {
+    const result = buildFlowPrompt({ 'role-definition': 'Du bist ein Marketing-Experte' });
+    expect(result).toContain('Du bist ein Marketing-Experte.');
+  });
+
+  it('does not double-punctuate role that already ends with period', () => {
+    const result = buildFlowPrompt({ 'role-definition': 'Du bist ein Experte.' });
+    expect(result).not.toContain('..');
+  });
+
+  it('includes content type with correct article', () => {
+    const result = buildFlowPrompt({ 'content-type': 'Blog-Post' });
+    expect(result).toContain('Erstelle einen Blog-Post.');
+  });
+
+  it('includes content type with correct article for feminine nouns', () => {
+    const result = buildFlowPrompt({ 'content-type': 'Pressemitteilung' });
+    expect(result).toContain('Erstelle eine Pressemitteilung.');
+  });
+
+  it('combines description and audience', () => {
+    const result = buildFlowPrompt({
+      'role-definition': 'Du bist Texter',
+      'description': 'KI-Tools',
+      'target-audience': 'Manager & Führungskräfte',
+    });
+    expect(result).toContain('Das Thema lautet: KI-Tools.');
+    expect(result).toContain('Die Zielgruppe sind Manager & Führungskräfte.');
+  });
+
+  it('includes length mapping', () => {
+    const result = buildFlowPrompt({
+      'role-definition': 'Texter',
+      'content-length': 'Kurz (100–300 Wörter)',
+    });
+    expect(result).toContain('Textlänge Kurz');
+  });
+
+  it('includes SEO keywords flag', () => {
+    const result = buildFlowPrompt({ 'role-definition': 'x', 'seo-keyword-option': 'Ja' });
+    expect(result).toContain('inklusive SEO-Keywords');
+  });
+
+  it('includes title/subtitle flag', () => {
+    const result = buildFlowPrompt({ 'role-definition': 'x', 'title-subtitle-option': 'ja' });
+    expect(result).toContain('mit Titel und Untertitel');
+  });
+
+  it('handles emoji variants', () => {
+    expect(buildFlowPrompt({ 'role-definition': 'x', 'emoji-option': 'keine' })).toContain('ohne Emojis');
+    expect(buildFlowPrompt({ 'role-definition': 'x', 'emoji-option': 'wenige' })).toContain('mit wenigen Emojis');
+    expect(buildFlowPrompt({ 'role-definition': 'x', 'emoji-option': 'viele' })).toContain('mit vielen Emojis');
+  });
+
+  it('includes language style', () => {
+    const result = buildFlowPrompt({ 'role-definition': 'x', 'language-style': 'Inspirierend' });
+    expect(result).toContain('inspirierend sein');
+  });
+
+  it('includes example reference', () => {
+    const result = buildFlowPrompt({ 'role-definition': 'x', 'beispiel': 'Beispieltext hier' });
+    expect(result).toContain('Orientiere dich stilistisch an folgendem Beispiel: Beispieltext hier');
+  });
+
+  it('prepends active project context', () => {
+    const ctx = { active: true, company: 'Acme GmbH', industry: 'Tech', extra: '' };
+    const result = buildFlowPrompt({ 'role-definition': 'Texter' }, ctx);
+    expect(result).toContain('[Projekt-Kontext: Firma/Projekt: Acme GmbH · Branche: Tech]');
+  });
+
+  it('omits project context when inactive', () => {
+    const ctx = { active: false, company: 'Acme GmbH' };
+    const result = buildFlowPrompt({ 'role-definition': 'Texter' }, ctx);
+    expect(result).not.toContain('Projekt-Kontext');
+  });
+});
+
+describe('buildFlowPromptEN', () => {
+  it('returns empty string for empty fields', () => {
+    expect(buildFlowPromptEN({})).toBe('');
+  });
+
+  it('produces English output for content type', () => {
+    const result = buildFlowPromptEN({ 'content-type': 'Blog-Post' });
+    expect(result).toContain('Create a blog post.');
+  });
+
+  it('produces different string than DE for same fields', () => {
+    const fields = {
+      'role-definition': 'Du bist ein Experte',
+      'content-type': 'Newsletter',
+      'description': 'KI im Marketing',
+    };
+    expect(buildFlowPrompt(fields)).not.toBe(buildFlowPromptEN(fields));
+  });
+
+  it('uses English audience label', () => {
+    const result = buildFlowPromptEN({
+      'role-definition': 'x',
+      'target-audience': 'Manager & Führungskräfte',
+    });
+    expect(result).toContain('managers and executives');
+  });
+
+  it('uses English style label', () => {
+    const result = buildFlowPromptEN({ 'role-definition': 'x', 'language-style': 'Formell' });
+    expect(result).toContain('formal');
+  });
+
+  it('prepends active project context in EN prompt', () => {
+    const ctx = { active: true, company: 'Acme', industry: '', extra: '' };
+    const result = buildFlowPromptEN({ 'role-definition': 'x' }, ctx);
+    expect(result).toContain('[Projekt-Kontext:');
+  });
+});
+
+describe('getCurrentPrompt', () => {
+  it('delegates to DE builder when lang is de', () => {
+    const fields = { 'content-type': 'Blog-Post' };
+    expect(getCurrentPrompt(fields, null, 'de')).toBe(buildFlowPrompt(fields));
+  });
+
+  it('delegates to EN builder when lang is en', () => {
+    const fields = { 'content-type': 'Blog-Post' };
+    expect(getCurrentPrompt(fields, null, 'en')).toBe(buildFlowPromptEN(fields));
+  });
+});
+
+describe('buildCtxPreviewText', () => {
+  it('returns empty string for null ctx', () => {
+    expect(buildCtxPreviewText(null)).toBe('');
+  });
+
+  it('returns empty string when inactive', () => {
+    expect(buildCtxPreviewText({ active: false, company: 'X' })).toBe('');
+  });
+
+  it('returns empty string when active but no fields', () => {
+    expect(buildCtxPreviewText({ active: true })).toBe('');
+  });
+
+  it('builds prefix from company and industry', () => {
+    const result = buildCtxPreviewText({ active: true, company: 'Acme', industry: 'SaaS', extra: '' });
+    expect(result).toBe('[Projekt-Kontext: Firma/Projekt: Acme · Branche: SaaS]');
+  });
+
+  it('includes extra briefing text', () => {
+    const result = buildCtxPreviewText({ active: true, company: '', industry: '', extra: 'B2B Fokus' });
+    expect(result).toContain('B2B Fokus');
+  });
+});

--- a/src/__tests__/score.test.js
+++ b/src/__tests__/score.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { calculateScore } from '../score.js';
+
+describe('calculateScore', () => {
+  it('returns count=0 and label=basis for empty fields', () => {
+    const { count, label } = calculateScore({});
+    expect(count).toBe(0);
+    expect(label).toBe('basis');
+  });
+
+  it('counts aufgabe when role-definition is set', () => {
+    const { count } = calculateScore({ 'role-definition': 'Experte' });
+    expect(count).toBe(1);
+  });
+
+  it('counts aufgabe when content-type is set', () => {
+    const { count } = calculateScore({ 'content-type': 'Blog-Post' });
+    expect(count).toBe(1);
+  });
+
+  it('counts aufgabe only once even when both role and type are set', () => {
+    const { count } = calculateScore({ 'role-definition': 'x', 'content-type': 'Blog-Post' });
+    expect(count).toBe(1);
+  });
+
+  it('counts kontext when description is set', () => {
+    const { count } = calculateScore({ 'role-definition': 'x', 'description': 'Topic' });
+    expect(count).toBe(2);
+  });
+
+  it('counts format when content-length is set', () => {
+    const { count } = calculateScore({
+      'role-definition': 'x',
+      'description': 'y',
+      'content-length': 'Kurz (100–300 Wörter)',
+    });
+    expect(count).toBe(3);
+    expect(calculateScore({ 'role-definition': 'x', 'description': 'y', 'content-length': 'Kurz (100–300 Wörter)' }).label).toBe('gut');
+  });
+
+  it('counts format when seo option is Ja', () => {
+    const { count } = calculateScore({ 'role-definition': 'x', 'seo-keyword-option': 'Ja' });
+    expect(count).toBe(2);
+  });
+
+  it('counts persona when perspective is set', () => {
+    const { count } = calculateScore({
+      'role-definition': 'x',
+      'description': 'y',
+      'content-length': 'z',
+      'perspective': 'Ich-Perspektive',
+    });
+    expect(count).toBe(4);
+  });
+
+  it('returns label=ausgezeichnet for 5+ filled groups', () => {
+    const fields = {
+      'role-definition': 'Experte',
+      'description': 'KI-Tools',
+      'content-length': 'Kurz (100–300 Wörter)',
+      'perspective': 'Ich-Perspektive',
+      'language-style': 'Sachlich',
+    };
+    const { count, label } = calculateScore(fields);
+    expect(count).toBe(5);
+    expect(label).toBe('ausgezeichnet');
+  });
+
+  it('returns count=6 when all 6 groups filled', () => {
+    const fields = {
+      'role-definition': 'Experte',
+      'description': 'KI-Tools',
+      'content-length': 'Kurz (100–300 Wörter)',
+      'perspective': 'Ich-Perspektive',
+      'language-style': 'Sachlich',
+      'beispiel': 'Stilreferenz',
+    };
+    const { count, label } = calculateScore(fields);
+    expect(count).toBe(6);
+    expect(label).toBe('ausgezeichnet');
+  });
+});

--- a/src/__tests__/storage.test.js
+++ b/src/__tests__/storage.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Storage } from '../storage.js';
+
+// Minimal localStorage mock for Node.js environment
+const store = {};
+global.localStorage = {
+  _store: store,
+  getItem(k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+  setItem(k, v) { store[k] = String(v); },
+  removeItem(k) { delete store[k]; },
+  clear() { Object.keys(store).forEach(k => delete store[k]); },
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('Storage.get', () => {
+  it('returns fallback for missing key', () => {
+    expect(Storage.get('nonexistent')).toBeNull();
+    expect(Storage.get('nonexistent', [])).toEqual([]);
+  });
+
+  it('returns parsed JSON value', () => {
+    localStorage.setItem('test', JSON.stringify({ a: 1 }));
+    expect(Storage.get('test')).toEqual({ a: 1 });
+  });
+
+  it('returns fallback for corrupt JSON', () => {
+    localStorage.setItem('corrupt', '{not valid json');
+    expect(Storage.get('corrupt', 'fallback')).toBe('fallback');
+  });
+
+  it('returns fallback when stored value is JSON null', () => {
+    localStorage.setItem('nullval', 'null');
+    expect(Storage.get('nullval', 'default')).toBe('default');
+  });
+});
+
+describe('Storage.set / Storage.get round-trip', () => {
+  it('stores and retrieves an array', () => {
+    const items = [{ id: 1, name: 'Test' }, { id: 2, name: 'Other' }];
+    Storage.set('items', items);
+    expect(Storage.get('items')).toEqual(items);
+  });
+
+  it('stores and retrieves an object', () => {
+    const obj = { activeLang: 'en', theme: 'dark' };
+    Storage.set('config', obj);
+    expect(Storage.get('config')).toEqual(obj);
+  });
+
+  it('stores and retrieves a boolean', () => {
+    Storage.set('flag', true);
+    expect(Storage.get('flag')).toBe(true);
+  });
+});
+
+describe('Storage.getString / Storage.setString', () => {
+  it('round-trips a raw string', () => {
+    Storage.setString('lang', 'de');
+    expect(Storage.getString('lang')).toBe('de');
+  });
+
+  it('returns null for missing key', () => {
+    expect(Storage.getString('missing')).toBeNull();
+  });
+});
+
+describe('Storage.remove', () => {
+  it('removes an existing key', () => {
+    Storage.set('key', 42);
+    Storage.remove('key');
+    expect(Storage.get('key')).toBeNull();
+  });
+
+  it('does not throw when removing non-existent key', () => {
+    expect(() => Storage.remove('nope')).not.toThrow();
+  });
+});

--- a/src/__tests__/variations.test.js
+++ b/src/__tests__/variations.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { buildVariations } from '../variations.js';
+
+describe('buildVariations', () => {
+  it('returns empty array when both type and description are missing', () => {
+    expect(buildVariations({})).toEqual([]);
+    expect(buildVariations({ 'language-style': 'Sachlich' })).toEqual([]);
+  });
+
+  it('returns up to 3 non-empty strings for DE', () => {
+    const vars = buildVariations({
+      'content-type': 'Blog-Post',
+      'description': 'KI-Tools im Alltag',
+      'target-audience': 'Berufstätige (30–50 Jahre)',
+    }, 'de');
+    expect(vars.length).toBeGreaterThanOrEqual(1);
+    expect(vars.length).toBeLessThanOrEqual(3);
+    vars.forEach(v => expect(v.trim().length).toBeGreaterThan(5));
+  });
+
+  it('returns up to 3 non-empty strings for EN', () => {
+    const vars = buildVariations({
+      'content-type': 'Blog-Post',
+      'description': 'AI tools in daily life',
+      'target-audience': 'Berufstätige (30–50 Jahre)',
+    }, 'en');
+    expect(vars.length).toBeGreaterThanOrEqual(1);
+    vars.forEach(v => expect(v.trim().length).toBeGreaterThan(5));
+  });
+
+  it('DE variations contain German keywords', () => {
+    const vars = buildVariations({ 'content-type': 'Newsletter', 'description': 'Digitalisierung' }, 'de');
+    const combined = vars.join(' ');
+    expect(combined).toMatch(/newsletter|verfasse|erstelle/i);
+  });
+
+  it('EN variations contain English keywords', () => {
+    const vars = buildVariations({ 'content-type': 'Newsletter', 'description': 'Digitalisation' }, 'en');
+    const combined = vars.join(' ');
+    expect(combined).toMatch(/write|create|newsletter/i);
+  });
+
+  it('includes format info when content-length is set', () => {
+    const vars = buildVariations({
+      'content-type': 'Artikel',
+      'description': 'Thema',
+      'content-length': 'Kurz (100–300 Wörter)',
+    }, 'de');
+    expect(vars.join(' ')).toContain('Kurz');
+  });
+
+  it('includes SEO info when seo option is Ja (DE)', () => {
+    const vars = buildVariations({
+      'content-type': 'SEO-Text',
+      'description': 'Keyword-Recherche',
+      'seo-keyword-option': 'Ja',
+    }, 'de');
+    expect(vars.join(' ')).toContain('SEO-Keywords');
+  });
+
+  it('defaults to DE when lang is omitted', () => {
+    const varsDefault = buildVariations({ 'content-type': 'Blog-Post', 'description': 'x' });
+    const varsDe = buildVariations({ 'content-type': 'Blog-Post', 'description': 'x' }, 'de');
+    expect(varsDefault).toEqual(varsDe);
+  });
+});

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -1,0 +1,137 @@
+// Pure prompt reverse-engineer — no DOM, no side-effects.
+// analyzePrompt(text) → partial fields object (keys from FIELD_IDS)
+
+/**
+ * Analyse a free-text prompt and extract recognised field values.
+ * Returns a partial object; callers should treat missing keys as unset.
+ */
+export function analyzePrompt(text) {
+  const result = {};
+
+  // Role / Persona
+  const rolePatterns = [
+    /(?:du bist|sie sind|agiere als|handele als)\s+([^.!?\n]{5,120})/i,
+    /(?:act as|you are|you're)\s+([^.!?\n]{5,120})/i,
+  ];
+  for (const p of rolePatterns) {
+    const m = text.match(p);
+    if (m) { result['role-definition'] = m[0].trim().replace(/[,.]$/, ''); break; }
+  }
+
+  // Content type
+  const typePatterns = [
+    { p: /pressemitteilung|press.?release/i,             v: 'Pressemitteilung' },
+    { p: /whitepaper/i,                                  v: 'Whitepaper' },
+    { p: /case.?stud/i,                                  v: 'Case-Study' },
+    { p: /newsletter/i,                                  v: 'Newsletter' },
+    { p: /landing.?page/i,                               v: 'Landing Page' },
+    { p: /linkedin/i,                                    v: 'LinkedIn-Beitrag' },
+    { p: /instagram/i,                                   v: 'Instagram-Beitrag' },
+    { p: /facebook/i,                                    v: 'Facebook-Beitrag' },
+    { p: /tweet|twitter/i,                               v: 'Twitter-Beitrag' },
+    { p: /tiktok/i,                                      v: 'TikTok-Skript' },
+    { p: /youtube/i,                                     v: 'YouTube-Video' },
+    { p: /podcast/i,                                     v: 'Podcast-Episode' },
+    { p: /executive.?summary/i,                          v: 'Executive Summary' },
+    { p: /bericht|report(?!\w)/i,                        v: 'Bericht / Report' },
+    { p: /stellenanzeige|job.?posting/i,                 v: 'Stellenanzeige' },
+    { p: /produktbeschreibung|product.?description/i,    v: 'Produktbeschreibung' },
+    { p: /seo.?text|seo.?artikel|seo.?article/i,        v: 'SEO-Text' },
+    { p: /how.?to|schritt.?für.?schritt|step.?by.?step/i, v: 'How-to-Anleitung' },
+    { p: /kaltakquise|cold.?outreach|cold.?email/i,     v: 'Kaltakquise-E-Mail' },
+    { p: /follow.?up/i,                                  v: 'Follow-up-E-Mail' },
+    { p: /e.?mail|email/i,                               v: 'E-Mail' },
+    { p: /präsentation|presentation/i,                   v: 'Präsentation' },
+    { p: /blog.?post|blogartikel/i,                      v: 'Blog-Post' },
+    { p: /artikel|article/i,                             v: 'Artikel' },
+  ];
+  for (const { p, v } of typePatterns) {
+    if (p.test(text)) { result['content-type'] = v; break; }
+  }
+
+  // Length
+  const wordMatch = text.match(/(\d+)\s*(?:wörter|wörtern|words)/i);
+  if (wordMatch) {
+    const n = parseInt(wordMatch[1]);
+    if (n <= 100)       result['content-length'] = 'Sehr kurz (50–100 Wörter)';
+    else if (n <= 300)  result['content-length'] = 'Kurz (100–300 Wörter)';
+    else if (n <= 600)  result['content-length'] = 'Mittel (300–600 Wörter)';
+    else if (n <= 1200) result['content-length'] = 'Lang (600–1.200 Wörter)';
+    else                result['content-length'] = 'Sehr lang (1.200+ Wörter)';
+  } else if (/\bkurz\b|brief|concise/i.test(text)) {
+    result['content-length'] = 'Kurz (100–300 Wörter)';
+  } else if (/ausführlich|detailliert|detailed|comprehensive|lang\b/i.test(text)) {
+    result['content-length'] = 'Lang (600–1.200 Wörter)';
+  }
+
+  // Style
+  const stylePatterns = [
+    { p: /wissenschaftlich|academic|scholarly/i,   v: 'Wissenschaftlich' },
+    { p: /journalistisch|journalistic/i,            v: 'Journalistisch' },
+    { p: /werblich|promotional/i,                   v: 'Werblich' },
+    { p: /technisch|technical/i,                    v: 'Technisch' },
+    { p: /humorvoll|humor|witzig|funny/i,           v: 'Humorvoll' },
+    { p: /inspir/i,                                 v: 'Inspirierend' },
+    { p: /emotiona/i,                               v: 'Emotional' },
+    { p: /motivier|motivat/i,                       v: 'Motivierend' },
+    { p: /sachlich|factual|neutral/i,               v: 'Sachlich' },
+    { p: /persönlich|personal/i,                    v: 'Persönlich' },
+    { p: /storytelling/i,                           v: 'Storytelling' },
+    { p: /formell|formal|professionell|professional/i, v: 'Formell' },
+    { p: /informell|locker|casual|informal/i,       v: 'Informell' },
+  ];
+  for (const { p, v } of stylePatterns) {
+    if (p.test(text)) { result['language-style'] = v; break; }
+  }
+
+  // Audience
+  const audiencePatterns = [
+    { p: /b2b.{0,20}entscheider|b2b.{0,20}decision/i, v: 'B2B-Entscheider' },
+    { p: /manager|führungskraft|executive|c-?level/i,  v: 'Manager & Führungskräfte' },
+    { p: /startup|gründer|founder/i,                   v: 'Gründer & Startups' },
+    { p: /it.?profes|entwickler|developer|programmer/i,v: 'IT-Professionals' },
+    { p: /senior|50\+|ältere/i,                        v: 'Senioren (50+ Jahre)' },
+    { p: /jugend|teenager|16.{0,3}25/i,                v: 'Jugendliche (16–25 Jahre)' },
+    { p: /schüler|student|auszubildend/i,              v: 'Schüler & Auszubildende (15–22 Jahre)' },
+    { p: /eltern|famili|parent|family/i,               v: 'Eltern & Familien' },
+    { p: /kreativ|designer|creative/i,                 v: 'Kreative & Designer' },
+    { p: /b2b|unternehmen|geschäftskund/i,             v: 'Manager & Führungskräfte' },
+  ];
+  for (const { p, v } of audiencePatterns) {
+    if (p.test(text)) { result['target-audience'] = v; break; }
+  }
+
+  // Formatting
+  if (/bullet.?point|aufzählung|stichpunkt/i.test(text))              result['formatting'] = 'Bullet Points';
+  else if (/tabelle|tabellarisch|table/i.test(text))                  result['formatting'] = 'Tabellarisch';
+  else if (/faq/i.test(text))                                         result['formatting'] = 'FAQ-Format (Frage & Antwort)';
+  else if (/checkliste|checklist/i.test(text))                        result['formatting'] = 'Checkliste / Aufgabenliste';
+  else if (/überschrift|heading|mit abschnitt/i.test(text))           result['formatting'] = 'Überschriften + Fließtext';
+
+  // SEO
+  if (/seo.?keyword|keyword|schlüsselwort/i.test(text))              result['seo-keyword-option'] = 'Ja';
+
+  // Emojis
+  if (/ohne emoji|no emoji/i.test(text))                             result['emoji-option'] = 'keine';
+  else if (/mit emoji|emojis|use emoji/i.test(text))                 result['emoji-option'] = 'wenige';
+
+  // Topic / Description
+  const topicPatterns = [
+    /(?:zum thema|über das thema|thema\s*[:\-])\s*([^.!?\n]{10,200})/i,
+    /(?:topic\s*[:\-]|about\s*[:\-]?|über\s*[:\-]?)\s*([^.!?\n]{10,200})/i,
+  ];
+  for (const p of topicPatterns) {
+    const m = text.match(p);
+    if (m) { result['description'] = m[1].trim(); break; }
+  }
+  if (!result['description']) {
+    const sentences = text.split(/[.!?]/).map(s => s.trim())
+      .filter(s => s.length > 25 && !/^(?:du bist|you are|act as|erstelle|create|write|schreibe|erzeuge|generate)/i.test(s));
+    if (sentences[0]) {
+      const s = sentences[0];
+      result['description'] = s.length > 160 ? s.substring(0, 160) + '…' : s;
+    }
+  }
+
+  return result;
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,4 @@
+// Module entry point — strangler-fig starting state.
+// The legacy script still contains all application logic;
+// new modules (prompt-builder, analyzer, etc.) are extracted incrementally.
+import '../script.js';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,34 @@
+// All application constants — no DOM, no side-effects.
+
+export const FIELD_IDS = [
+  'role-definition',
+  'content-type', 'description', 'content-length', 'target-audience',
+  'language-style', 'perspective', 'emoji-option', 'address-form',
+  'formatting', 'seo-keyword-option', 'title-subtitle-option', 'beispiel',
+];
+
+export const LS_FORM_KEY      = 'chati_form';
+export const LS_HISTORY_KEY   = 'chati_history';
+export const LS_LIBRARY_KEY   = 'chati_library';
+export const LS_PRESETS_KEY   = 'chati_presets';
+export const LS_FAVORITES_KEY = 'chati_favorites';
+export const LS_THEME_KEY     = 'chati_theme';
+export const LS_PROJECT_CTX   = 'chati_project_ctx';
+export const LS_RECENT_KEY    = 'chati_recent';
+export const LS_ONBOARDED_KEY = 'chati_onboarded';
+export const LS_VAULT_KEY     = 'chati_vault';
+export const LS_UI_LANG_KEY   = 'chati_ui_lang';
+
+export const HISTORY_MAX = 8;
+export const VAULT_MAX   = 10;
+
+export const THEMES = ['light', 'dark', 'ocean', 'violet', 'forest'];
+
+export const STEP_BODIES = [
+  'body-aufgabe',
+  'body-kontext',
+  'body-format',
+  'body-persona',
+  'body-tonfall',
+  'body-beispiel',
+];

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -1,0 +1,140 @@
+// All translation/mapping tables extracted from script.js
+// These are pure data objects — no DOM dependencies.
+
+export const LENGTH_MAP = {
+  'Sehr kurz (50–100 Wörter)':  'Sehr kurz',
+  'Kurz (100–300 Wörter)':      'Kurz',
+  'Mittel (300–600 Wörter)':    'Mittel',
+  'Lang (600–1.200 Wörter)':    'Lang',
+  'Sehr lang (1.200+ Wörter)':  'Sehr lang',
+};
+
+export const LENGTH_MAP_EN = {
+  'Sehr kurz (50–100 Wörter)':  'very short (50–100 words)',
+  'Kurz (100–300 Wörter)':      'short (100–300 words)',
+  'Mittel (300–600 Wörter)':    'medium (300–600 words)',
+  'Lang (600–1.200 Wörter)':    'long (600–1,200 words)',
+  'Sehr lang (1.200+ Wörter)':  'very long (1,200+ words)',
+};
+
+export const ADDRESS_MAP    = { formal: 'Sie-Form', informell: 'Du-Form', neutral: 'Neutral', kombiniert: 'Kombiniert' };
+export const ADDRESS_MAP_EN = { formal: 'formal (Sie)', informell: 'informal (du)', neutral: 'neutral', kombiniert: 'mixed' };
+
+export const FORMAT_MAP_EN = {
+  'Fließtext':               'flowing prose',
+  'Überschriften + Fließtext': 'headings with prose',
+  'Bullet Points':           'bullet points',
+  'Nummerierte Liste':       'numbered list',
+  'Schritt-für-Schritt':     'step-by-step',
+  'Tabellarisch':            'tabular layout',
+  'Zitat':                   'quote format',
+  'FAQ-Format (Frage & Antwort)': 'FAQ format (Q&A)',
+  'Checkliste / Aufgabenliste':   'checklist / task list',
+};
+
+export const STYLE_MAP_EN = {
+  'Emotional': 'emotional', 'Empathisch': 'empathetic', 'Formell': 'formal',
+  'Humorvoll': 'humorous', 'Informell': 'informal', 'Inspirierend': 'inspiring',
+  'Journalistisch': 'journalistic', 'Minimalistisch': 'minimalist',
+  'Motivierend': 'motivational', 'Persönlich': 'personal', 'Poetisch': 'poetic',
+  'Provokativ': 'provocative', 'Sachlich': 'factual', 'Seriös': 'serious',
+  'Storytelling': 'storytelling', 'Technisch': 'technical',
+  'Umgangssprachlich': 'colloquial', 'Werblich': 'promotional',
+  'Wissenschaftlich': 'scientific',
+};
+
+export const AUDIENCE_MAP_EN = {
+  'Jugendliche (16–25 Jahre)':        'teenagers and young adults (16–25)',
+  'Junge Erwachsene (25–35 Jahre)':   'young adults (25–35)',
+  'Berufstätige (30–50 Jahre)':       'working professionals (30–50)',
+  'Eltern & Familien':                'parents and families',
+  'Senioren (50+ Jahre)':             'seniors (50+)',
+  'Gründer & Startups':               'founders and startups',
+  'KMU-Inhaber & Selbstständige':     'SME owners and freelancers',
+  'Manager & Führungskräfte':         'managers and executives',
+  'B2B-Entscheider':                  'B2B decision-makers',
+  'IT-Professionals':                 'IT professionals',
+  'Technik & Digitales':              'tech enthusiasts',
+  'Fitness & Gesundheit':             'fitness and health community',
+  'Mode & Lifestyle':                 'fashion and lifestyle audience',
+  'Finanzen & Investment':            'finance and investment community',
+  'Bildung & Weiterbildung':          'education and learning community',
+  'Schüler & Auszubildende (15–22 Jahre)': 'students and trainees (15–22)',
+  'Kreative & Designer':              'creatives and designers',
+  'Lehrkräfte & Pädagogen':           'teachers and educators',
+  'Sport & Outdoor':                  'sports and outdoor enthusiasts',
+  'Nachhaltigkeit & Umwelt':          'sustainability and environmental community',
+};
+
+export const PERSPECTIVE_MAP_EN = {
+  'Du-Perspektive': 'second person (you)',
+  'Er-/Sie-Perspektive': 'third person',
+  'Ich-Perspektive': 'first person (I)',
+  'Neutral/Objektiv': 'neutral/objective',
+  'Wir-Perspektive': 'first person plural (we)',
+};
+
+export const ARTICLE_MAP = {
+  'Artikel': 'einen ', 'Blog-Post': 'einen ', 'How-to-Anleitung': 'eine ', 'Listicle (Top-X-Artikel)': 'einen ',
+  'Interview': 'ein ', 'Whitepaper': 'ein ', 'Case-Study': 'eine ',
+  'Pressemitteilung': 'eine ', 'E-Book': 'ein ', 'Buchrezension': 'eine ', 'Zusammenfassung': 'eine ',
+  'Facebook-Beitrag': 'einen ', 'Instagram-Beitrag': 'einen ',
+  'Story-Skript (Instagram / Facebook)': 'ein ', 'Carousel-Post': 'einen ',
+  'LinkedIn-Beitrag': 'einen ', 'Twitter-Beitrag': 'einen ',
+  'TikTok-Skript': 'ein ', 'Reels-Skript': 'ein ',
+  'Threads-Beitrag': 'einen ', 'Xing-Beitrag': 'einen ',
+  'Produktbeschreibung': 'eine ', 'Verkaufstext / Sales Page': 'einen ', 'Produktvergleich': 'einen ',
+  'FAQ-Seite': 'eine ', 'Anzeige': 'eine ', 'SEO-Text': 'einen ',
+  'Newsletter': 'einen ', 'Landing Page': 'eine ',
+  'E-Mail': 'eine ', 'Kaltakquise-E-Mail': 'eine ', 'Follow-up-E-Mail': 'eine ',
+  'Onboarding-E-Mail': 'eine ', 'Kundenservice-Antwort': 'eine ',
+  'Präsentation': 'eine ', 'Executive Summary': 'ein ', 'Bericht / Report': 'einen ',
+  'Angebot / Proposal': 'ein ', 'Meeting-Protokoll': 'ein ',
+  'Stellenanzeige': 'eine ', 'Bewerbungsschreiben': 'ein ',
+  'YouTube-Video': 'ein ', 'YouTube-Short-Skript': 'ein ',
+  'Podcast-Episode': 'eine ', 'Infografik': 'eine ',
+  'Webinar': 'ein ', 'Live-Stream': 'einen ',
+  'Slogan / Claim': 'einen ', 'Kurzgeschichte': 'eine ',
+  'Gedicht / Lyrik': 'ein ', 'Drehbuch / Skript': 'ein ',
+  'Online-Quiz': 'ein ', 'Chatbot': 'einen ', 'Online-Kurs': 'einen ',
+  'Erfahrungsbericht': 'einen ', 'Checkliste': 'eine ', 'Glossar / Lexikon': 'ein ',
+  'Produkttest / Review': 'einen ', 'Meta-Description (SEO)': 'eine ',
+  'Einladungsschreiben': 'ein ', 'Dankes-E-Mail': 'eine ',
+  'Unternehmensvorstellung': 'eine ', 'Vision & Mission Statement': 'ein ',
+  'Produktname / Naming': 'ein ',
+};
+
+export const ARTICLE_MAP_EN = {
+  'Artikel': 'an article', 'Blog-Post': 'a blog post',
+  'How-to-Anleitung': 'a how-to guide', 'Listicle (Top-X-Artikel)': 'a listicle',
+  'Interview': 'an interview', 'Whitepaper': 'a whitepaper',
+  'Case-Study': 'a case study', 'Pressemitteilung': 'a press release', 'E-Book': 'an e-book',
+  'Buchrezension': 'a book review', 'Zusammenfassung': 'a summary',
+  'Facebook-Beitrag': 'a Facebook post', 'Instagram-Beitrag': 'an Instagram caption',
+  'Story-Skript (Instagram / Facebook)': 'a story script', 'Carousel-Post': 'a carousel post',
+  'LinkedIn-Beitrag': 'a LinkedIn post', 'Twitter-Beitrag': 'a tweet',
+  'TikTok-Skript': 'a TikTok script', 'Reels-Skript': 'a Reels script',
+  'Threads-Beitrag': 'a Threads post', 'Xing-Beitrag': 'a Xing post',
+  'Produktbeschreibung': 'a product description', 'Verkaufstext / Sales Page': 'a sales page',
+  'Produktvergleich': 'a product comparison', 'FAQ-Seite': 'an FAQ page',
+  'Anzeige': 'an advertisement', 'SEO-Text': 'an SEO article',
+  'Newsletter': 'a newsletter', 'Landing Page': 'a landing page',
+  'E-Mail': 'an email', 'Kaltakquise-E-Mail': 'a cold outreach email',
+  'Follow-up-E-Mail': 'a follow-up email', 'Onboarding-E-Mail': 'an onboarding email',
+  'Kundenservice-Antwort': 'a customer service response',
+  'Präsentation': 'a presentation', 'Executive Summary': 'an executive summary',
+  'Bericht / Report': 'a report', 'Angebot / Proposal': 'a business proposal',
+  'Meeting-Protokoll': 'a meeting minutes document',
+  'Stellenanzeige': 'a job posting', 'Bewerbungsschreiben': 'a cover letter',
+  'YouTube-Video': 'a YouTube video description', 'YouTube-Short-Skript': 'a YouTube Shorts script',
+  'Podcast-Episode': 'a podcast episode outline',
+  'Infografik': 'an infographic', 'Webinar': 'a webinar', 'Live-Stream': 'a live stream script',
+  'Slogan / Claim': 'a slogan', 'Kurzgeschichte': 'a short story',
+  'Gedicht / Lyrik': 'a poem', 'Drehbuch / Skript': 'a script',
+  'Online-Quiz': 'an online quiz', 'Chatbot': 'a chatbot script', 'Online-Kurs': 'an online course outline',
+  'Erfahrungsbericht': 'a testimonial / experience report', 'Checkliste': 'a checklist',
+  'Glossar / Lexikon': 'a glossary', 'Produkttest / Review': 'a product review',
+  'Meta-Description (SEO)': 'a meta description', 'Einladungsschreiben': 'an invitation letter',
+  'Dankes-E-Mail': 'a thank-you email', 'Unternehmensvorstellung': 'a company introduction',
+  'Vision & Mission Statement': 'a vision & mission statement', 'Produktname / Naming': 'a product name concept',
+};

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -1,0 +1,130 @@
+// Pure prompt-building functions — no DOM reads, no side-effects.
+// fields = plain object with FIELD_IDS keys
+// ctx    = { active: bool, company: string, industry: string, extra: string } | null
+
+import {
+  ARTICLE_MAP, ARTICLE_MAP_EN,
+  LENGTH_MAP, LENGTH_MAP_EN,
+  FORMAT_MAP_EN, STYLE_MAP_EN,
+  AUDIENCE_MAP_EN, PERSPECTIVE_MAP_EN,
+  ADDRESS_MAP, ADDRESS_MAP_EN,
+} from './mappings.js';
+
+/**
+ * Build the project-context prefix line for DE and EN prompts.
+ * Returns empty string when context is inactive or empty.
+ */
+export function buildCtxPreviewText(ctx) {
+  if (!ctx?.active) return '';
+  const parts = [];
+  if (ctx.company)  parts.push(`Firma/Projekt: ${ctx.company}`);
+  if (ctx.industry) parts.push(`Branche: ${ctx.industry}`);
+  if (ctx.extra)    parts.push(ctx.extra);
+  return parts.length ? `[Projekt-Kontext: ${parts.join(' · ')}]` : '';
+}
+
+/**
+ * Build the German prompt string from a fields object.
+ */
+export function buildFlowPrompt(fields, ctx = null) {
+  const role        = fields['role-definition']      || '';
+  const type        = fields['content-type']         || '';
+  const description = fields['description']          || '';
+  const audience    = fields['target-audience']      || '';
+  const length      = fields['content-length']       || '';
+  const formatting  = fields['formatting']           || '';
+  const seo         = fields['seo-keyword-option']   || '';
+  const titleSub    = fields['title-subtitle-option'] || '';
+  const perspective = fields['perspective']          || '';
+  const addressForm = fields['address-form']         || '';
+  const style       = fields['language-style']       || '';
+  const emojis      = fields['emoji-option']         || '';
+  const beispiel    = fields['beispiel']             || '';
+
+  if (!role && !type && !description) return '';
+  const s = [];
+
+  const ctxText = buildCtxPreviewText(ctx);
+  if (ctxText) s.push(ctxText);
+  if (role) s.push(role.endsWith('.') || role.endsWith('!') || role.endsWith('?') ? role : role + '.');
+  if (type) s.push(`Erstelle ${(ARTICLE_MAP[type] ?? 'einen ')}${type}.`);
+  if (description && audience) s.push(`Das Thema lautet: ${description}. Die Zielgruppe sind ${audience}.`);
+  else if (description) s.push(`Das Thema lautet: ${description}.`);
+  else if (audience) s.push(`Die Zielgruppe sind ${audience}.`);
+
+  const fp = [];
+  if (length) fp.push(`Textlänge ${LENGTH_MAP[length] || length}`);
+  if (formatting) fp.push(`Formatierung als ${formatting}`);
+  if (seo === 'Ja') fp.push('inklusive SEO-Keywords');
+  if (titleSub === 'ja') fp.push('mit Titel und Untertitel');
+  if (emojis === 'keine') fp.push('ohne Emojis');
+  else if (emojis === 'wenige') fp.push('mit wenigen Emojis');
+  else if (emojis === 'viele') fp.push('mit vielen Emojis');
+  if (fp.length) s.push(`Verwende ${fp.join(', ')}.`);
+
+  const pp = [];
+  if (perspective) pp.push(perspective);
+  if (addressForm) pp.push(ADDRESS_MAP[addressForm] || addressForm);
+  if (pp.length) s.push(`Schreibe aus der ${pp.join(', in der ')}.`);
+  if (style) s.push(`Der Sprachstil soll ${style.toLowerCase()} sein.`);
+  if (beispiel) s.push(`Orientiere dich stilistisch an folgendem Beispiel: ${beispiel}`);
+
+  return s.join(' ');
+}
+
+/**
+ * Build the English prompt string from a fields object.
+ */
+export function buildFlowPromptEN(fields, ctx = null) {
+  const role        = fields['role-definition']      || '';
+  const type        = fields['content-type']         || '';
+  const description = fields['description']          || '';
+  const audience    = fields['target-audience']      || '';
+  const length      = fields['content-length']       || '';
+  const formatting  = fields['formatting']           || '';
+  const seo         = fields['seo-keyword-option']   || '';
+  const titleSub    = fields['title-subtitle-option'] || '';
+  const perspective = fields['perspective']          || '';
+  const addressForm = fields['address-form']         || '';
+  const style       = fields['language-style']       || '';
+  const emojis      = fields['emoji-option']         || '';
+  const beispiel    = fields['beispiel']             || '';
+
+  if (!role && !type && !description) return '';
+  const s = [];
+
+  const ctxText = buildCtxPreviewText(ctx);
+  if (ctxText) s.push(ctxText);
+  if (role) s.push(role.endsWith('.') || role.endsWith('!') || role.endsWith('?') ? role : role + '.');
+  if (type) s.push(`Create ${ARTICLE_MAP_EN[type] ?? 'a ' + type}.`);
+  if (description && audience)
+    s.push(`The topic is: ${description}. The target audience is ${AUDIENCE_MAP_EN[audience] || audience}.`);
+  else if (description) s.push(`The topic is: ${description}.`);
+  else if (audience) s.push(`The target audience is ${AUDIENCE_MAP_EN[audience] || audience}.`);
+
+  const fp = [];
+  if (length) fp.push(`text length: ${LENGTH_MAP_EN[length] || length}`);
+  if (formatting) fp.push(`format: ${FORMAT_MAP_EN[formatting] || formatting}`);
+  if (seo === 'Ja') fp.push('include SEO keywords');
+  if (titleSub === 'ja') fp.push('include title and subtitle');
+  if (emojis === 'keine') fp.push('no emojis');
+  else if (emojis === 'wenige') fp.push('few emojis');
+  else if (emojis === 'viele') fp.push('many emojis');
+  if (fp.length) s.push(`Use the following: ${fp.join(', ')}.`);
+
+  const pp = [];
+  if (perspective) pp.push(PERSPECTIVE_MAP_EN[perspective] || perspective);
+  if (addressForm) pp.push(ADDRESS_MAP_EN[addressForm] || addressForm);
+  if (pp.length) s.push(`Write from a ${pp.join(', ')} perspective.`);
+  if (style) s.push(`The tone should be ${STYLE_MAP_EN[style] || style.toLowerCase()}.`);
+  if (beispiel) s.push(`Stylistically, follow this example: ${beispiel}`);
+
+  return s.join(' ');
+}
+
+/**
+ * Select the appropriate builder based on language.
+ */
+export function getCurrentPrompt(fields, ctx, lang) {
+  return lang === 'en' ? buildFlowPromptEN(fields, ctx) : buildFlowPrompt(fields, ctx);
+}

--- a/src/score.js
+++ b/src/score.js
@@ -1,0 +1,35 @@
+// Pure score calculation — no DOM, no side-effects.
+
+/**
+ * Calculate how many of the 6 prompt sections are filled.
+ * Mirrors the PREVIEW_GROUPS logic from script.js without DOM reads.
+ *
+ * @param {Object} fields  Plain object with FIELD_IDS keys
+ * @returns {{ count: number, label: 'basis'|'gut'|'ausgezeichnet' }}
+ */
+export function calculateScore(fields) {
+  const groups = [
+    // aufgabe: role-definition or content-type
+    Boolean(fields['role-definition'] || fields['content-type']),
+    // kontext: description or target-audience
+    Boolean(fields['description'] || fields['target-audience']),
+    // format: any format-related field
+    Boolean(
+      fields['content-length'] ||
+      fields['formatting'] ||
+      (fields['emoji-option'] && fields['emoji-option'] !== '') ||
+      fields['seo-keyword-option'] === 'Ja' ||
+      fields['title-subtitle-option'] === 'ja'
+    ),
+    // persona: perspective or address-form
+    Boolean(fields['perspective'] || fields['address-form']),
+    // tonfall: language-style
+    Boolean(fields['language-style']),
+    // beispiel
+    Boolean(fields['beispiel']),
+  ];
+
+  const count = groups.filter(Boolean).length;
+  const label = count >= 5 ? 'ausgezeichnet' : count >= 3 ? 'gut' : 'basis';
+  return { count, label };
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,34 @@
+import { FIELD_IDS } from './constants.js';
+
+// Centralised mutable state — replaces scattered `let` variables from the closure.
+export const state = {
+  activeLang: 'de',
+  uiLang: 'de',
+  activeTab: 'visual',
+  editedPromptText: null,
+  focusMode: false,
+  activeCardId: null,
+  activeFilter: 'alle',
+  catalogSearchQuery: '',
+  libSearch: '',
+  histSearch: '',
+  allCollapsed: false,
+  activeLibTab: 'mine',
+  activeExampleFilter: 'alle',
+  onboardingStep: 0,
+  lastFormState: null,
+};
+
+/**
+ * Read all form fields from the DOM and return a plain object.
+ * Keys match FIELD_IDS; only non-empty values are included.
+ */
+export function getFormState() {
+  const data = {};
+  for (const id of FIELD_IDS) {
+    const el = document.getElementById(id);
+    const v = (el?.value ?? '').trim();
+    if (v) data[id] = v;
+  }
+  return data;
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,29 @@
+// Thin localStorage wrapper — replaces ~15 identical try/catch blocks in script.js.
+
+export const Storage = {
+  get(key, fallback = null) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return fallback;
+      return JSON.parse(raw) ?? fallback;
+    } catch {
+      return fallback;
+    }
+  },
+
+  set(key, value) {
+    try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
+  },
+
+  getString(key) {
+    try { return localStorage.getItem(key); } catch { return null; }
+  },
+
+  setString(key, value) {
+    try { localStorage.setItem(key, value); } catch {}
+  },
+
+  remove(key) {
+    try { localStorage.removeItem(key); } catch {}
+  },
+};

--- a/src/variations.js
+++ b/src/variations.js
@@ -1,0 +1,118 @@
+// Pure prompt variations builder — no DOM, no side-effects.
+
+import {
+  ARTICLE_MAP, ARTICLE_MAP_EN,
+  LENGTH_MAP, LENGTH_MAP_EN,
+  FORMAT_MAP_EN, STYLE_MAP_EN,
+  AUDIENCE_MAP_EN, PERSPECTIVE_MAP_EN,
+  ADDRESS_MAP, ADDRESS_MAP_EN,
+} from './mappings.js';
+
+/**
+ * Build 3 alternative phrasings of a prompt.
+ *
+ * @param {Object} fields  Plain object with FIELD_IDS keys
+ * @param {string} lang    'de' | 'en'
+ * @returns {string[]}     Array of 0–3 variation strings
+ */
+export function buildVariations(fields, lang = 'de') {
+  const type        = fields['content-type']          || '';
+  const description = fields['description']           || '';
+  const audience    = fields['target-audience']       || '';
+  const length      = fields['content-length']        || '';
+  const formatting  = fields['formatting']            || '';
+  const seo         = fields['seo-keyword-option']    || '';
+  const titleSub    = fields['title-subtitle-option'] || '';
+  const perspective = fields['perspective']           || '';
+  const addressForm = fields['address-form']          || '';
+  const style       = fields['language-style']        || '';
+  const emojis      = fields['emoji-option']          || '';
+  const beispiel    = fields['beispiel']              || '';
+
+  if (!type && !description) return [];
+
+  if (lang === 'en') {
+    const art = ARTICLE_MAP_EN[type] ?? 'a ' + (type || '');
+    const fp = [];
+    if (length)   fp.push(LENGTH_MAP_EN[length] || length);
+    if (formatting) fp.push(FORMAT_MAP_EN[formatting] || formatting);
+    if (seo === 'Ja') fp.push('SEO keywords');
+    if (titleSub === 'ja') fp.push('title');
+    if (emojis === 'keine') fp.push('no emojis');
+    else if (emojis === 'wenige') fp.push('few emojis');
+    else if (emojis === 'viele') fp.push('many emojis');
+    const fmt = fp.join(', ');
+    const aud = AUDIENCE_MAP_EN[audience] || audience;
+    const sty = STYLE_MAP_EN[style] || style;
+
+    const v1 = [];
+    if (type) v1.push(`Write ${art}.`);
+    if (description) v1.push(`Topic: ${description}.`);
+    if (audience)    v1.push(`Audience: ${aud}.`);
+    if (fmt)         v1.push(`Format: ${fmt}.`);
+    if (style)       v1.push(`Style: ${sty}.`);
+    if (beispiel)    v1.push(`Reference: ${beispiel}`);
+
+    const v2 = [];
+    if (description) v2.push(`About "${description}": `);
+    if (type)        v2.push(`Write ${art}${audience ? ` for ${aud}` : ''}.`);
+    const det = [];
+    if (fmt)   det.push(fmt);
+    if (style) det.push(`${sty} tone`);
+    if (perspective) det.push(PERSPECTIVE_MAP_EN[perspective] || perspective);
+    if (det.length) v2.push(`Consider: ${det.join(', ')}.`);
+    if (beispiel) v2.push(`Base your style on: ${beispiel}`);
+
+    const v3 = [];
+    v3.push(style ? `You are a ${sty} copywriter.` : 'You are an experienced copywriter.');
+    if (type && description) v3.push(`Create ${art} about: ${description}.`);
+    else if (type)            v3.push(`Create ${art}.`);
+    if (audience) v3.push(`Target audience: ${aud}.`);
+    if (fmt)      v3.push(`Format: ${fmt}.`);
+    if (addressForm) v3.push(`Use ${ADDRESS_MAP_EN[addressForm] || addressForm} address form.`);
+    if (beispiel) v3.push(`Style reference: ${beispiel}`);
+
+    return [v1.join(' '), v2.join(''), v3.join(' ')].filter(v => v.trim().length > 5);
+  }
+
+  // German
+  const art = ARTICLE_MAP[type] ?? 'einen ';
+  const fp = [];
+  if (length)   fp.push(LENGTH_MAP[length] || length);
+  if (formatting) fp.push(formatting);
+  if (seo === 'Ja') fp.push('SEO-Keywords');
+  if (titleSub === 'ja') fp.push('Titel');
+  if (emojis === 'keine') fp.push('keine Emojis');
+  else if (emojis === 'wenige') fp.push('wenige Emojis');
+  else if (emojis === 'viele') fp.push('viele Emojis');
+  const fmt = fp.join(', ');
+
+  const v1 = [];
+  if (type) v1.push(`Verfasse ${art}${type}.`);
+  if (description) v1.push(`Thema: ${description}.`);
+  if (audience)    v1.push(`Zielgruppe: ${audience}.`);
+  if (fmt)         v1.push(`Format: ${fmt}.`);
+  if (style)       v1.push(`Stil: ${style}.`);
+  if (beispiel)    v1.push(`Referenz: ${beispiel}`);
+
+  const v2 = [];
+  if (description) v2.push(`Zum Thema „${description}": `);
+  if (type)        v2.push(`Schreibe ${art}${type}${audience ? ` für ${audience}` : ''}.`);
+  const det = [];
+  if (fmt)   det.push(fmt);
+  if (style) det.push(`${style.toLowerCase()} Stil`);
+  if (perspective) det.push(perspective);
+  if (det.length) v2.push(`Berücksichtige: ${det.join(', ')}.`);
+  if (beispiel) v2.push(`Orientiere dich an: ${beispiel}`);
+
+  const v3 = [];
+  v3.push(style ? `Du bist ein ${style.toLowerCase()} schreibender Texter.` : 'Du bist ein erfahrener Texter.');
+  if (type && description) v3.push(`Erstelle ${art}${type} über: ${description}.`);
+  else if (type)            v3.push(`Erstelle ${art}${type}.`);
+  if (audience) v3.push(`Zielgruppe: ${audience}.`);
+  if (fmt)      v3.push(`Format: ${fmt}.`);
+  if (addressForm) v3.push(`Schreibe in der ${ADDRESS_MAP[addressForm] || addressForm}.`);
+  if (beispiel) v3.push(`Stilreferenz: ${beispiel}`);
+
+  return [v1.join(' '), v2.join(''), v3.join(' ')].filter(v => v.trim().length > 5);
+}

--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,28 @@
 'use strict';
 
-const CACHE  = 'chati-v1.4';
+const CACHE  = 'chati-v2.0';
 const ASSETS = [
   './',
   './index.html',
   './styles.css',
   './script.js',
   './catalog.js',
+  './examples.js',
   './manifest.json',
   './icon.svg',
   './icon-192.png',
   './icon-512.png',
   './apple-touch-icon.png',
   './favicon-32.png',
+  './src/app.js',
+  './src/constants.js',
+  './src/mappings.js',
+  './src/state.js',
+  './src/storage.js',
+  './src/prompt-builder.js',
+  './src/analyzer.js',
+  './src/score.js',
+  './src/variations.js',
 ];
 
 self.addEventListener('install', e => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary

Major internal refactoring that introduces ES module architecture, extracts pure functions from the monolithic `script.js`, and adds comprehensive test coverage — all with **zero user-facing changes**.

### What changed

**Architecture (strangler-fig migration)**
- `index.html` now loads a single `<script type="module" src="src/app.js">` instead of 3 separate `<script>` tags
- `catalog.js` and `examples.js` gain `export` keywords
- `script.js` imports all extracted symbols at the top

**Pure function extraction (~460 lines moved out of `script.js`)**
| Module | Responsibility |
|---|---|
| `src/mappings.js` | All translation / article maps (LENGTH_MAP, ARTICLE_MAP, ADDRESS_MAP, …) |
| `src/prompt-builder.js` | `buildFlowPrompt`, `buildFlowPromptEN`, `buildCtxPreviewText` — fields-object API, no DOM reads |
| `src/analyzer.js` | `analyzePrompt` — regex-based prompt reverse-engineering |
| `src/score.js` | `calculateScore` — 6-group scoring, pure |
| `src/variations.js` | `buildVariations` — 3 alternative phrasings, pure |

**Infrastructure modules**
| Module | Responsibility |
|---|---|
| `src/constants.js` | `FIELD_IDS`, all `LS_*` keys, `HISTORY_MAX`, `VAULT_MAX`, `THEMES` |
| `src/storage.js` | Storage wrapper replacing ~15 identical try/catch localStorage blocks |
| `src/state.js` | Central state object + `getFormState()` DOM bridge |

**Constant cleanup**
- `LS_RECENT_KEY`, `LS_ONBOARDED_KEY`, `LS_VAULT_KEY`, `VAULT_MAX` hoisted to top-level constants block
- New `LS_UI_LANG_KEY` named constant replaces raw `'chati_ui_lang'` string

**Service worker**
- Cache version bumped to `chati-v2.0`
- All `src/*.js` modules added to the precache asset list

**Testing**
- 75 vitest tests across 5 suites — all passing
- Covers: analyzer, prompt-builder, score, storage, variations

**Stats:** 20 files changed, +1,234 insertions, −473 deletions

## Test plan

- [ ] Run `npx vitest run` — all 75 tests pass
- [ ] Open `index.html` in browser — app loads and functions identically
- [ ] Verify prompt generation (DE + EN) produces same output as `main`
- [ ] Verify compare modal, variations, and analyzer work correctly
- [ ] Confirm service worker caches all new `src/*.js` files
- [ ] Test offline mode still works after cache update


Made with [Cursor](https://cursor.com)